### PR TITLE
Compatibility fixes

### DIFF
--- a/src/manual/js_bindings_core.h
+++ b/src/manual/js_bindings_core.h
@@ -175,7 +175,7 @@ extern "C" {
 	// logs a format string to the console
 	JSBool JSBCore_log(JSContext *cx, uint32_t argc, jsval *vp);
 
-	extern char* JSB_version;
+	extern const char* JSB_version;
 #ifdef __cplusplus
 }
 #endif

--- a/src/manual/js_bindings_core.mm
+++ b/src/manual/js_bindings_core.mm
@@ -48,7 +48,7 @@ static tHashJSObject *reverse_hash = NULL;
 // Globals
 char * JSB_association_proxy_key = NULL;
 
-char * JSB_version = "0.3-beta";
+const char * JSB_version = "0.3-beta";
 
 
 static void its_finalize(JSFreeOp *fop, JSObject *obj)


### PR DESCRIPTION
// Rect compatibility API
cc.rectEqualToRect = cc.Rect.CCRectEqualToRect;
cc.rectContainsRect = cc.Rect.CCRectContainsRect;
cc.rectGetMaxX = cc.Rect.CCRectGetMaxX;
cc.rectGetMidX = cc.Rect.CCRectGetMidX;
cc.rectGetMinX = cc.Rect.CCRectGetMinX;
cc.rectGetMaxY = cc.Rect.CCRectGetMaxY;
cc.rectGetMidY = cc.Rect.CCRectGetMidY;
cc.rectGetMinY = cc.Rect.CCRectGetMinY;
cc.rectContainsPoint = cc.Rect.CCRectContainsPoint;
cc.rectIntersectsRect = cc.Rect.CCRectIntersectsRect;
cc.rectUnion = cc.Rect.CCRectUnion;
cc.rectIntersection = cc.Rect.CCRectIntersection;
