### PR TITLE
Fix error when class has callbacks but no manual methods.

### DIFF
--- a/generate_jsb.py
+++ b/generate_jsb.py
@@ -1492,7 +1492,7 @@ extern JSClass *%s_class;
             for m in self.callback_methods[class_name]:
 
                 # ignore manual
-                if m in self.manual_methods[class_name]:
+                if class_name in self.manual_methods and m in self.manual_methods[class_name]:
                     continue
 
                 method = self.get_method(class_name, m)


### PR DESCRIPTION
Fixes KeyError when a class has callbacks but no "manual methods."
