### PR TITLE
Add JS roots for the function and the 'this' JSObject

### DIFF
--- a/src/manual/jsb_basic_conversions.h
+++ b/src/manual/jsb_basic_conversions.h
@@ -118,6 +118,22 @@ jsval JSB_jsval_from_opaque( JSContext *cx, void* opaque);
 jsval JSB_jsval_from_c_class( JSContext *cx, void* handle, JSObject* object, JSClass *klass, const char* optional_class_name);
 /* Converts a char ptr into a jsval (using JS string) */
 jsval JSB_jsval_from_charptr( JSContext *cx, const char *str);
+jsval JSB_jsval_from_unknown( JSContext *cx, id obj);
+
+/** Adds GC roots for funcval and jsthis tied to the lifetime of a block */
+@interface JSB_Callback : NSObject
+{
+}
+@property (nonatomic, readonly, assign) JSContext *cx;
+@property (nonatomic, readonly, assign) JSObject *jsthis;
+@property (nonatomic, readonly, assign) jsval funcval;
+
+- (id) initWithContext:(JSContext *)cx funcval:(jsval)funcval jsthis:(JSObject*)jsthis;
+
+@end
+
+JSB_Callback* JSB_prepare_callback( JSContext *cx, JSObject *jsthis, jsval funcval);
+JSBool JSB_execute_callback( JSB_Callback *cb, unsigned argc, jsval *argv, jsval *rval);
 
 
 #ifndef _UINT32

--- a/src/manual/jsb_cocos2d_manual.mm
+++ b/src/manual/jsb_cocos2d_manual.mm
@@ -1311,13 +1311,14 @@ JSBool JSB_CCScheduler_scheduleBlockForKey_target_interval_repeat_delay_paused_b
 		key = [NSString stringWithFormat:@"anonfunc at %p", func];
 	}
 
+	JSB_Callback *cb = JSB_prepare_callback(cx, jstarget, funcval);
 	void (^block)(ccTime dt) = ^(ccTime dt) {
 
 		jsval rval;
 		jsval jsdt = DOUBLE_TO_JSVAL(dt);
 
 		JSB_ENSURE_AUTOCOMPARTMENT(cx, jstarget);
-		JSBool ok = JS_CallFunctionValue(cx, jstarget, funcval, 1, &jsdt, &rval);
+		JSBool ok = JSB_execute_callback(cb, 1, &jsdt, &rval);
 		JSB_PRECONDITION2(ok, cx, ,"Error calling collision callback: schedule_interval_repeat_delay");
 	};
 


### PR DESCRIPTION
Add JS roots for the function and the 'this' JSObject for the life of the callback.

Objective-C blocks create strong references to closed over objects. We
use this property to tie the lifetime of the JSB_Callback to the block's
lifetime. Once the block is dealloc'd, the JSB_Callback removes the JS
roots to the function and the 'this' JSObject.
