### PR TITLE
update for Update jsb_basic_conversions.mm

### DIFF
--- a/src/manual/jsb_basic_conversions.mm
+++ b/src/manual/jsb_basic_conversions.mm
@@ -277,8 +277,13 @@ JSBool JSB_jsval_to_unknown(JSContext *cx, jsval vp, id* ret)
 	else if (JSVAL_IS_STRING(vp)) {
 		return JSB_jsval_to_NSString( cx, vp, ret );
 	}
-	// Null or undefined
-	else if (JSVAL_IS_NULL(vp) || JSVAL_IS_VOID(vp)) {
+	// Null
+	else if (JSVAL_IS_NULL(vp)) {
+		*ret = [NSNull class];
+		return JS_TRUE;
+	}
+	// undefined
+	else if (JSVAL_IS_VOID(vp)) {
 		*ret = NULL;
 		return JS_TRUE;
 	}


### PR DESCRIPTION
fixed rounding bug in JSB_jsval_from_NSNumber
this bug results in a wrong number in js
1.4 (native) -> 1.400000024556 (js)

JSB_jsval_to_NSSet now uses a real NSSet

in JSB_jsval_to_NSDictionary the key can be a number or a string
-> now JSB_jsval_from_NSDictionary also

JSB_jsval_to_unknown:
if a jsvalue is null, it should generate a [NSNull null]
JSB_jsval_from_unknown works in the same way with "return JSVAL_NULL"
NSJSONSerialization also geneates a NSNull from a "null" js value
If a js value in a dictionary is null it should not be skipped I think.
Null is also a information that can be handled and make sense same times.
