### PR TITLE
Add a \n and ASCII character 23 at the end of each debugger response

### DIFF
--- a/src/js/jsb_debugger.js
+++ b/src/js/jsb_debugger.js
@@ -259,7 +259,11 @@ textCommandProcessor.getCommandProcessor = function (str) {
 
 var jsonResponder = {};
 
-jsonResponder.write = _bufferWrite;
+jsonResponder.write = function (str) {
+    _bufferWrite(str);
+    _bufferWrite("\n");
+    _bufferWrite(String.fromCharCode(23));
+}
 
 jsonResponder.onBreakpoint = function (filename, linenumber) {
     var response = {"from" : "server",


### PR DESCRIPTION
Needed for CocosBuilder to detect end of message.
