### PR TITLE
Updated generate_jsb.py to support 'int64_t' (alias for 'long long')

### DIFF
--- a/generate_jsb.py
+++ b/generate_jsb.py
@@ -458,6 +458,10 @@ class JSBGenerate(object):
         if dt == 'id':
             dt = 'NSObject*'
 
+        # Treat 'int64_t' as long long
+        if dt == 'int64_t':
+            t='Q';
+
         dt_class_name = dt.replace('*', '')
 
         # IMPORTANT: 1st search on declared types.


### PR DESCRIPTION
Maps 'int64_t' to the already supported 'Q' (long long) type.
